### PR TITLE
Fix for MDL-61269

### DIFF
--- a/_docs/getting-started/development/moodle.md
+++ b/_docs/getting-started/development/moodle.md
@@ -163,12 +163,10 @@ $CFG->behat_config = array_merge(array(
             'selenium2' => array(
                 'wd_host' => 'http://192.168.120.100:4444/wd/hub',
                 'capabilities' => array(
-                    'browserVersion'    => 'ANY',
                     'deviceType'        => 'ANY',
                     'name'              => 'ANY',
                     'deviceOrientation' => 'ANY',
                     'ignoreZoomSetting' => 'ANY',
-                    'version'           => 'ANY',
                     'platform'          => 'ANY',
                 ),
             ),


### PR DESCRIPTION
This bug prevents Behat tests from running. It is documented as [MDL-61269: Incorrect defaults/capabilities prevent hub to find matching nodes](https://tracker.moodle.org/browse/MDL-61269).

If encountered:
1. update config.php
2. rsync the app-debug VM(s)
3. re-initialise the Behat test environment.